### PR TITLE
Add vitest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint:css": "stylelint \"**/*.{css,scss}\"",
     "format": "prettier --write \"**/*.{js,ts,tsx,css,md,mdx,json}\"",
     "reset": "rm -rf node_modules .next .eslintcache .cache package-lock.json pnpm-lock.yaml && pnpm install",
-    "nvmrc": "echo $(node -p -e 'require(\"./package\").engines.node.split(\">=\").join(\"\")') > .nvmrc"
+    "nvmrc": "echo $(node -p -e 'require(\"./package\").engines.node.split(\">=\").join(\"\")') > .nvmrc",
+    "test": "vitest",
+    "test:watch": "vitest --watch"
   },
   "dependencies": {
     "@mantine/colors-generator": "7.17.0",
@@ -55,7 +57,10 @@
     "stylelint-order": "6.0.4",
     "tailwindcss": "4.0.9",
     "tailwindcss-animate": "1.0.7",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "vitest": "1.5.3",
+    "@testing-library/react": "14.1.2",
+    "@testing-library/jest-dom": "6.4.2"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/src/components/features/navs/top-nav/__tests__/NavLinks.test.tsx
+++ b/src/components/features/navs/top-nav/__tests__/NavLinks.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { NavLinks } from '../NavLinks';
+
+// Mock next/link to render a simple anchor element
+vi.mock('next/link', () => {
+  return {
+    default: ({ href, children, ...rest }: any) => (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('NavLinks component', () => {
+  it('renders all navigation links', () => {
+    render(<NavLinks />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(5);
+    expect(links[0]).toHaveTextContent('About');
+    expect(links[0]).toHaveAttribute('href', '/about');
+  });
+});

--- a/src/lib/__tests__/mdx.test.ts
+++ b/src/lib/__tests__/mdx.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { listAllMdxMeta, getAllSlugs, readMdxContent } from '../mdx';
+
+const BLOG_SLUG = 'test-post';
+const PROJECT_SLUG = 'test-project';
+
+describe('mdx utilities', () => {
+  it('lists metadata for blogs', () => {
+    const items = listAllMdxMeta('blogs');
+    const slugs = items.map((i) => i.slug);
+    expect(slugs).toContain(BLOG_SLUG);
+    const item = items.find((i) => i.slug === BLOG_SLUG)!;
+    expect(item.frontMatter.title).toBeDefined();
+  });
+
+  it('retrieves all project slugs', () => {
+    const slugs = getAllSlugs('projects');
+    expect(slugs).toContain(PROJECT_SLUG);
+  });
+
+  it('reads MDX content', () => {
+    const result = readMdxContent('projects', PROJECT_SLUG);
+    expect(result).not.toBeNull();
+    expect(result!.data.title).toBe('Serverless Image Processor');
+    expect(result!.content).toMatch(/Serverless Image Processor/);
+  });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../utils';
+
+describe('cn utility', () => {
+  it('merges class names', () => {
+    expect(cn('text-blue-500', 'bg-red-500')).toBe('text-blue-500 bg-red-500');
+  });
+
+  it('deduplicates conflicting classes', () => {
+    const result = cn('p-2', { 'text-gray-700': true, 'text-blue-500': false }, 'p-4');
+    expect(result).toBe('text-gray-700 p-4');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- add vitest config and setup files
- add unit tests for utility functions
- test MDX helper functions
- add tests for navigation links component

## Testing
- `pnpm exec vitest run` *(fails: Command "vitest" not found)*